### PR TITLE
docs: refresh Task1–13 project overview

### DIFF
--- a/FILE_INDEX.md
+++ b/FILE_INDEX.md
@@ -32,6 +32,9 @@
 
 ## Specifications and plans
 
+- `README.md`、`README.en.md`：Task1–13 后的产品入口；以治理型写作运行时为当前主架构，并明确真实发布状态与 OSS 能力边界。
+- `docs/plans/2026-08-31-readme-task1-13-refresh-design.md`：README 信息架构、双版本边界与真实性约束。
+- `docs/plans/2026-08-31-readme-task1-13-refresh.md`：Task1–13 中英文 README 双仓刷新实施计划。
 - `specs/lcp/v1/`：Lumin Content Protocol schema 与纵向场景 fixture。
 - `specs/task11-governed-materials/`：Task11 材料、事实源与 B2 契约规格。
 - `specs/task12-governed-rollout/`：Task12 三类适配器、shadow、埋点和发布门禁规格。

--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,8 @@
 
 [中文](README.md) · [Live workspace](https://luminbuddy2.ericdocmic.top/v2/) · [Changelog](#changelog)
 
+**Edition: OSS** — includes the governed writing kernel, MCP, baseline retrieval, and extension contracts; excludes commercial paid-search providers, credential settings, and proprietary connectors.
+
 > **An AI writing workspace for Chinese content creators**: from intent understanding, source retrieval, and outline confirmation, to style-aware drafting, post-review, feedback, and memory sedimentation—transforming one-shot generation into an observable, interruptible, and iterative writing process.
 
 ![LuminBuddy writing workspace](docs/assets/luminbuddy-workspace.png)
@@ -12,52 +14,59 @@
 
 **LuminBuddy** is an AI writing assistant designed for Chinese content production. It doesn't pursue "one-click generation" magic, but instead breaks down the writing process into observable, interruptible, and iterative engineering workflows—keeping creators in control at key decision points while AI assists in source gathering, structure planning, style adaptation, and quality checking.
 
-**Current maturity: Engineering Beta**. The repository contains a complete frontend and backend, Harness single-layer Agent orchestration, writing Pipeline, guided outlines, style profiles, A/B evaluation, feedback system, tiered memory, and monitoring metrics; continuously iterating.
+**Current maturity: Engineering Beta; the governed kernel is connected to the primary flow.** Task1–13 delivered WritingContract, plan compilation, LCP/Document AST, typed Artifacts, transactional storage, runtime orchestration, three quality gates, V2 APIs, a document-first workspace, governed materials, shadow rollout, and production wiring. Code, builds, CI, and three real writing paths in an isolated environment pass; production traffic still requires staging evidence, recovery/cancel/rollback drills, and credential rotation.
 
-### Governed Writing Runtime: Target Architecture and Migration Boundary
+### Governed Writing Runtime
 
-V2 evolves toward the [Governed Writing Runtime](docs/19-governed-writing-runtime.md) as its single target architecture and protocol baseline, delivered through the [implementation plan](docs/plans/2026-08-27-governed-writing-runtime-implementation.md). New capabilities must bind a versioned WritingContract, ExecutablePlan, Artifact, quality state, and Snapshot. The document is the primary product object; chat is the channel for changing the contract, explaining decisions, and controlling execution.
+The [Governed Writing Runtime](docs/19-governed-writing-runtime.md) is the single authoritative writing kernel for V2. Every new task binds a versioned WritingContract and a statically validated ExecutablePlan. Models and legacy operators may submit only typed Artifacts or Revisions; they cannot bypass quality gates to overwrite the official document.
 
-During migration, the existing Harness, Pipeline, and Editorial DAG remain available as executors or compatibility adapters:
-
-- `agent.start` and `workflow.start` retain wire compatibility for now, but they are not two parallel authoritative runtimes.
-- Legacy `mode` and `agent_mode` are not the new `task_mode`, `orchestration_mode`, and `assurance_level`; old fields must not carry the new semantics.
-- `agent.completed` and `workflow.completed` only mean the current executor path ended. They do not mean the content is Accepted, Verified, or formally committed.
-- The Article Output Contract only defines the streaming Markdown parsing boundary. Successful parsing does not imply LCP validation, Document AST construction, version commit, or quality acceptance.
+- **The document is the primary object:** chat changes the contract, explains decisions, and controls execution; body text, versions, citations, and quality states belong to the document.
+- **writingstore is the sole source of truth:** Contract, Plan, Run, Artifact, Decision, Ledger, Snapshot, and canonical/shadow content are persisted together.
+- **Quality states cannot be fabricated:** Candidate Draft, Accepted Draft, and Verified Deliverable advance monotonically. A BLOCKER, a missing required validator, or a missing complete snapshot prevents Verified.
+- **Legacy capabilities are governed adapters:** Harness, Pipeline, and Editorial Roles run through ExecutorAdapter and do not form a parallel source of truth. Contract, permission, budget, or lineage violations fail closed.
+- **Release claims stay evidence-based:** process health, run completion, or successful Markdown parsing does not mean a deliverable was accepted, verified, or approved for production traffic.
 
 ---
 
 ## Problems Solved
 
-General chat models can draft quickly, but real writing work usually fails at four points:
+General chat models can draft quickly, but real writing work usually fails at these points:
 
 | Pain Point | Manifestation | LuminBuddy's Solution |
 |------------|--------------|----------------------|
-| **Unstable intent understanding** | User's real needs, length, and style constraints not accurately captured | Rule-first intent routing + low-confidence LLM fallback |
-| **Black-box generation** | Source retrieval, opinion organization, and drafting compressed into one unobservable generation | Harness single-layer orchestration, every step visible, pausable, resumable |
-| **Loss of control at key points** | Users can't intervene at high-cost decision points like outline confirmation or style adjustment | Guided Mode: confirm outline before drafting |
-| **Feedback doesn't accumulate** | Good/bad feedback doesn't enter next generation; team can't locate failure points | Section feedback + A/B evaluation + tiered memory system |
+| **Intent drifts in long context** | Requirements, length, style, and evidence constraints are gradually lost | WritingContract records explicit choices, inference sources, and delivery criteria |
+| **Generation is a black box** | Materials, planning, execution, and drafting collapse into one opaque response | ExecutablePlan, RunLedger, and durable events make work observable, cancellable, and recoverable |
+| **Materials lose provenance** | Multi-source synthesis drops conflicts, snapshots, or citation relationships | MaterialAdapter, SourcePack, content snapshots, and lineage govern every input |
+| **Users lose control at costly decisions** | A system can execute expensive or risky work before review | Automatic and manual strategies coexist; high-cost, high-risk, and manual tasks require confirmation |
+| **“Generated” is mistaken for deliverable** | Correct formatting does not prove facts, style, or contract compliance | Candidate / Accepted / Verified gates with non-waivable BLOCKER findings |
+| **Failures create conflicting versions** | Retries, restarts, and duplicate events can corrupt state | Idempotent commits, complete checkpoints, snapshots, pause/cancel/rollback, and shadow isolation |
 
 ---
 
 ## How It Works
 
-### Core Architecture: Harness-LLM Single-Layer Continuous Session
+### Core Architecture: Contract-Driven Document Runtime
 
-Inspired by DeepSeek Harness (dsh), adopts a **single-layer architecture**:
-
+```text
+User request / materials / explicit strategy
+  → WritingContract (goal, style, evidence, budget, permissions, approval)
+  → Strategy Compiler → ExecutablePlan (bounded DAG + capability binding)
+  → Orchestrator → ExecutorAdapter (Harness / Engine Step / Editorial Role)
+  → typed Artifact + lineage + usage
+  → LCP / Document AST / RevisionSet
+  → Quality Gate (Candidate → Accepted → Verified)
+  → writingstore atomically commits DocumentVersion + Snapshot + RunLedger
+  → frontend projects the document, run summary, detail report, and chat controls
 ```
-User Request
-  → Harness (intent routing, tool registration, state management, circuit breaking)
-    → LLM continuous session (autonomously decides which tools to call, when to write, when to revise)
-      ←→ Tool execution (search/knowledge base/write/review/revise)
-  → Streaming output to frontend
-```
 
-**Key designs**:
-- **No nested ReAct + inner agent loop**, reducing latency and output drift
-- **1 LLM continuous session** replaces traditional Pipeline's 10+ independent calls, time-to-first-token from 30-60s to 3-5s
-- **Cross-turn session persistence**: articles, sources, search records accumulate and reuse within the same dialog
+The compiler selects among templates, the capability registry, and constrained extension strategies. Unknown capabilities, unbounded retries, missing inputs, permission violations, budget overflow, and missing final artifacts are rejected before execution.
+
+### Automatic Execution and User Control
+
+- Ordinary tasks: execute immediately after the system compiles the plan; the plan remains visible and cancellable.
+- High-cost or high-risk tasks: require confirmation of plan and budget.
+- Manual mode: explicit user choices win; system recommendations cannot silently replace them.
+- Mid-run changes: chat updates the contract or sends control commands; provisional stream content cannot overwrite a committed document version.
 
 ### Smart Context Management
 
@@ -75,15 +84,16 @@ System Prompt reduced from full injection (3000+ tokens) to resident layer (500-
 ### Writing Flow
 
 ```text
-Writing Request
-  → Intent Recognition (rule-first, ms-level routing)
-  → Memory Retrieval (user preference injection)
-  → Source Retrieval (multi-source search + knowledge base + relevance filtering)
-  → Outline Confirmation (guided mode: confirm/edit/redo)
-  → Style-aware Streaming Writing (generate according to Profile rules)
-  → Post-review (quality scoring + safety check)
-  → Auto-fix (low-severity issues auto-fixed)
-  → Section Feedback + A/B Evaluation + Memory Sedimentation
+Create or revise WritingContract
+  → normalize user materials, web sources, and knowledge results
+  → compile and validate ExecutablePlan
+  → execute automatically or await confirmation by cost/risk/user policy
+  → produce typed Outline, SectionDraft, ResearchNote, and ClaimMap Artifacts
+  → compile Document AST and create Candidate Draft
+  → validate contract, style, facts, citations, and safety
+  → advance to Accepted Draft only with no BLOCKER
+  → produce Verified Deliverable only after required validators and complete Snapshot
+  → continue user edits, RevisionSets, feedback, evaluation, and memory in one document lifecycle
 ```
 
 ---
@@ -94,18 +104,20 @@ Writing Request
 
 | Feature | Description |
 |---------|-------------|
-| **Intent Recognition** | Rule-first routing, supports writing/polish/compress/expand/free chat |
-| **Multi-source Retrieval** | Extensible multi-source search framework + internal knowledge base (BM25 + Dense + GraphRAG) |
-| **Guided Mode** | Outline confirmation, editing, up to five regenerations |
+| **WritingContract** | Captures task mode, style, materials, evidence, budget, permissions, approval, and delivery requirements |
+| **Adaptive Planning** | T1–T4 trust levels, capability binding, static validation, and explicit user strategy precedence |
+| **Three Writing Scenarios** | Long-form creation, multi-material synthesis, faithful rewrite, and their fail-closed paths |
+| **Material Governance** | Material/SourcePack/ClaimMap Artifacts, conflict Findings, citations, and content snapshots |
 | **Style Configuration** | Style Profile independently managed, supports versioning, grayscale release and rollback |
-| **Streaming Output** | WebSocket real-time push, supports pause/resume/cancel |
+| **Document-First Workspace** | Document stage, collapsible global panel, run summary, detail tabs, and resizable bottom chat |
+| **Durable Run Control** | WebSocket durable events, pause/resume/cancel, idempotent commit, and restart recovery |
 | **Rich Text Editor** | Tiptap/ProseMirror editor with bold, lists, blockquotes, code blocks |
-| **Quality Review** | 6-dimension scoring (factuality/structure/style/rhetoric/length/safety) |
-| **Auto-fix** | Auto-correct when review fails, up to 3 attempts |
+| **Three Quality States** | Candidate / Accepted / Verified, validator degradation, BLOCKER, and full audit reports |
+| **Isolated Rollout** | off/shadow/allowlist/percentage policy, shadow isolation, TTL, and rollback protection |
 
 ### Writing Toolset
 
-Tools LLM autonomously calls during continuous session:
+The governed runtime schedules built-in and adapted tools through the Capability Registry. Tool output must become a typed Artifact and cannot directly commit the official document:
 
 | Tool | Purpose |
 |------|---------|
@@ -121,7 +133,7 @@ Tools LLM autonomously calls during continuous session:
 | `fact_check` | Extract factual claims and verify through search |
 | `retrieve_context` | On-demand retrieval of session context |
 
-> **Search Source Extension**: This repo provides the complete `SearchClient` interface and multi-source concurrent search framework. Search sources are integrated as independent modules. Developers can refer to the stub implementations in `search_stubs.go` to connect their own search sources.
+> **Search boundary:** OSS includes the common retrieval contracts, local knowledge retrieval, bounded shared web fetching, and extension interfaces. It does not register commercial paid providers or include their credential variables or CLIs.
 
 ### Online Editing & Export
 
@@ -144,15 +156,17 @@ Supports file-layer bidirectional sync (Markdown file ↔ database), human-reada
 
 ### Editorial Multi-Agent Collaboration
 
-A complete three-Agent orchestration system for editorial content production:
+Research, writing, and review roles are governed Executor capabilities behind the shared Orchestrator:
 
 ```
-Human editor creates task → Research Agent → Writing Agent → Review Agent
-  → Quality routing: pass → pending publish / minor issues → return / severe → escalate to human
+WritingContract → constrained role plan → research/writing/review Artifacts
+  → shared quality gates → document version or human decision
 ```
 
 - **Role-based Agent Executor** (RoleAgentRunner): Each Agent has independent Persona, toolset, and signal tools
 - **Tool Registry Management** (EditorialToolRegistry): Add new tools with `Register`, no switch-case modification needed
+- **Single commit path**: Roles return ExecutionResult; only the Orchestrator writes to writingstore
+- **Missing dependencies fail closed**: An incomplete registry, permission, input, or usage record cannot become success
 - **Three-layer Model**: Event (objective facts) + Decision (human/system choices) + Transition (state changes)
 - **Quality Routing**: Source count, information gaps, verified claims auto-scored, auto-advance when passing
 - **Agent Reputation**: Records success rate, Token cost, quality scores
@@ -199,46 +213,29 @@ Implements the Agent Card concept from the A2A (Agent-to-Agent) protocol, where 
 ## Technical Architecture
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│                    Frontend (React 19 + Vite)                 │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────────┐  │
-│  │ Writing  │ │ Topic    │ │ Personal │ │ Admin          │  │
-│  │ Workspace│ │ Center   │ │ Center   │ │ Dashboard      │  │
-│  └─────┬────┘ └─────┬────┘ └─────┬────┘ └───────┬────────┘  │
-│        └────────────┴────────────┘              │           │
-│                     │                           │           │
-│              WebSocket + REST                   │           │
-└─────────────────────┼───────────────────────────┼───────────┘
-                      │                           │
-┌─────────────────────┼───────────────────────────┼───────────┐
-│              Go Backend (chi router)             │           │
-│                     │                           │           │
-│  ┌──────────────────┴───────────────────────────┴────────┐  │
-│  │                   Harness Agent Engine                 │  │
-│  │  ┌────────┐  ┌─────────┐  ┌────────┐  ┌────────────┐  │  │
-│  │  │ Intent │→ │ Search  │→ │ Write  │→ │PostReview  │  │  │
-│  │  │Routing │  │  Plan   │  │ Step   │  │   Step     │  │  │
-│  │  └────────┘  └─────────┘  └────────┘  └────────────┘  │  │
-│  │                                                        │  │
-│  │  ┌────────┐  ┌─────────┐  ┌────────┐  ┌────────────┐  │  │
-│  │  │ Memory │  │  Style  │  │  A/B   │  │  Feedback  │  │  │
-│  │  │  Gate  │  │ Profile │  │  Eval  │  │  System    │  │  │
-│  │  └────────┘  └─────────┘  └────────┘  └────────────┘  │  │
-│  └────────────────────────────────────────────────────────┘  │
-│                     │                                       │
-│  ┌──────────┬──────────┬──────────┬──────────┬──────────┐  │
-│  │ DeepSeek │  Search  │ IMA KB   │ DashScope│ MCP Server│  │
-│  │  Client  │  Client  │  Client  │ Embedding│ (JSON-RPC) │  │
-│  └──────────┴──────────┴──────────┴──────────┴──────────┘  │
-└─────────────────────┬───────────────────────────────────────┘
-                      │
-┌─────────────────────┼───────────────────────────────────────┐
-│              PostgreSQL 17 + pgvector + paradedb             │
-│  ┌─────────┬──────────┬──────────┬──────────┬────────────┐  │
-│  │ User    │ Style    │ Knowledge│ Memory   │ Session    │  │
-│  │ Data    │ Profiles │ Base     │ System   │ Logs       │  │
-│  └─────────┴──────────┴──────────┴──────────┴────────────┘  │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ React writing workspace                                          │
+│ global panel │ document stage │ run summary │ details │ chat     │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │ REST + WebSocket durable events
+┌───────────────────────────▼──────────────────────────────────────┐
+│ Go API / Governed Composition Root                               │
+│ Contract API │ Plan/Run API │ Document API │ Quality/Audit API   │
+├──────────────────────────────────────────────────────────────────┤
+│ writingkernel → writingplan → writingruntime → writingquality    │
+│ Contract       Compiler       Orchestrator      Validators        │
+│ LCP/AST        Registry       Recovery/Rollout  Quality Gates     │
+├──────────────────────────────────────────────────────────────────┤
+│ ExecutorAdapter: Harness Core │ Engine Step │ Editorial Role      │
+│ Shared capabilities: local retrieval │ web fetch │ MCP │ memory  │
+├──────────────────────────────────────────────────────────────────┤
+│ writingstore: Contract / Plan / Run / Artifact / Decision /       │
+│ Ledger / DocumentVersion / Snapshot / canonical / shadow          │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │
+┌───────────────────────────▼──────────────────────────────────────┐
+│ PostgreSQL 17 + pgvector + ParadeDB │ Redis wake-up │ object data │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ### Tech Stack
@@ -251,7 +248,8 @@ Implements the Agent Card concept from the A2A (Agent-to-Agent) protocol, where 
 | LLM | DeepSeek API (default), supports OpenAI compatible interface |
 | Embedding | DashScope text-embedding-v3 (1024-dim) |
 | Deployment | Docker Compose, 1Panel |
-| Monitoring | Prometheus metrics + slog structured logging + Trace tracking |
+| Runtime Protocol | LCP v1, WritingContract, ExecutablePlan, typed Artifact, durable RunEvent |
+| Monitoring | Prometheus metrics + slog structured logging + RunLedger + Trace tracking |
 
 ---
 
@@ -261,11 +259,11 @@ Implements the Agent Card concept from the A2A (Agent-to-Agent) protocol, where 
 
 ```bash
 cp .env.docker.example .env.docker
-# Edit .env.docker: fill in model API keys and database password
+# Edit .env.docker with only the model, embedding, and database settings you need locally
 docker compose up -d
 ```
 
-Frontend at `http://localhost:3002`, backend health at `http://localhost:8080/api/v2/health`.
+Frontend is at `http://localhost:3002`. `/api/v2/health` only means the process is alive; check `http://localhost:8080/api/v2/ready` for production dependencies. Never commit real credentials.
 
 ### Local Development
 
@@ -280,9 +278,11 @@ cd frontend && npm ci && npm run dev
 ### Validation
 
 ```bash
-cd backend && go test ./...
-cd frontend && npm ci && npm run build
+make verify
+docker compose config --quiet
 ```
+
+`make verify` runs the Go build and full test suite plus frontend lint, production build, and WaBench tests. PostgreSQL integration tests should use the CI-equivalent ParadeDB image with both `vector` and `pg_search`, and set `TEST_DATABASE_URL`.
 
 ### Deployment Packaging
 
@@ -296,13 +296,14 @@ cd frontend && npm ci && npm run build
 
 ### Search Source Extension
 
-This repo provides the search client core framework (`backend/internal/tools/search.go`), including:
-- `SearchClient` multi-source concurrent search struct
-- `NewSearchClient` constructor
-- `Search` / `FetchHotTopics` concurrent search methods
-- `KnowledgeSearcher` knowledge base search interface
+OSS shares:
 
-Search sources are integrated as independent modules. This repo provides stub implementations for all search source types in `search_stubs.go`. Developers can refer to these stubs to connect their own search sources:
+- common `SearchClient` / `KnowledgeSearcher` contracts and the Capability Registry;
+- local knowledge retrieval plus bounded shared web fetching and extraction;
+- MCP Client/Server, discovery, readiness, and sandboxing;
+- fail-closed stubs and tests for custom search adapters.
+
+Paid provider implementations, credential variables, and commercial CLIs are not part of OSS. A custom source must return governed Source/SourcePack Artifacts and declare permissions, timeout, cost, and stable errors:
 
 ```go
 // Example: implement a custom search source
@@ -311,11 +312,11 @@ type MySearchClient struct { /* ... */ }
 func NewMySearchClient(/* params */) *MySearchClient { /* ... */ }
 
 func (c *MySearchClient) Search(ctx context.Context, query string, limit int) ([]engine.SearchResult, error) {
-    // Your search logic
+    // Return results with source, timestamp, and provenance metadata
 }
 ```
 
-Then initialize your search source in `NewSearchClient`.
+Do not turn an uninstalled provider into fake success or an unexplained empty result. `/ready` distinguishes installed, configured, reachable, and ready.
 
 ---
 
@@ -338,10 +339,25 @@ Then initialize your search source in `NewSearchClient`.
 | [Luminbuddy Eval Center](docs/16-wabench-eval-center.md) | Seven evaluation workspaces, Chinese Excel, review traceability |
 | [WritingAgentBench V2](docs/14-wabench-v2-evaluation.md) | Real Harness Adapter, five Rubric, failure-first, independent red team |
 | [Runbook](docs/runbook.md) | Deployment, monitoring, troubleshooting |
+| [Governed Writing Runtime](docs/19-governed-writing-runtime.md) | Contract, Plan, LCP, document, quality, snapshot, workspace, and edition boundaries |
+| [Task1–12 Implementation](docs/plans/2026-08-27-governed-writing-runtime-implementation.md) | Domain protocol through workspace, materials, and vertical release gates |
+| [LCP v1](specs/lcp/v1/README.md) | Schemas, enums, fixtures, and three writing scenarios |
+| [Task11 Governed Materials](specs/task11-governed-materials/design.md) | MaterialAdapter, typed Artifacts, conflict handling, and the sole source of truth |
+| [Task12 Governed Rollout](specs/task12-governed-rollout/design.md) | ExecutorAdapters, shadow isolation, telemetry, and rollback |
+| [Task13 Production Wiring](docs/releases/2026-08-30-task13-production-wiring-readiness.md) | Passed evidence, remaining production gates, and credential boundaries |
 
 ---
 
 ## Changelog
+
+### v0.8.0 (2026-08-31) — Task1–13 Governed Writing Platform
+
+- **Task1–4 · Protocol and planning:** unified architecture boundary; LCP v1, WritingContract, Document AST, RevisionSet, typed Writing Plan IR, Capability Registry, and T1–T4 strategy compilation.
+- **Task5–7 · Persistence and execution:** governed schema, transactional Repository, immutable RunLedger, atomic Snapshot commits, state machine, ExecutorRegistry, budget/permission/approval gates, and bounded recovery.
+- **Task8–10 · Quality, API, and workspace:** Candidate/Accepted/Verified, non-waivable BLOCKER, validator degradation, V2 Contract/Document/Run/Quality/Audit APIs, and the document-first four-region workspace.
+- **Task11 · Governed materials:** MaterialAdapter, typed Material/Source Artifacts, conflict Findings, single Orchestrator commit path, and B2 contracts for legacy operators.
+- **Task12 · Governed rollout:** three ExecutorAdapters, shadow-content isolation, rollout evidence, telemetry, defense matrix, and three vertical scenarios.
+- **Task13 · Production wiring:** unified composition root, readiness/provider preflight, MCP concurrency hardening, canonical/shadow persistence, and real-model path acceptance. Production traffic remains gated by staging evidence.
 
 ### v0.7.0 (2026-08-24)
 
@@ -403,7 +419,8 @@ Then initialize your search source in `NewSearchClient`.
 ## Project Disclaimer
 
 - This is a runnable personal product and engineering project, not a validated commercial deployment.
-- Search sources are integrated as independent modules; refer to `search_stubs.go` stub implementations to connect your own.
+- Code, builds, CI, and isolated real paths pass; this is not approval for production deployment or traffic.
+- OSS shares the governed kernel, MCP, baseline retrieval, web fetching, and extension contracts; it excludes commercial paid-search implementations and credentials.
 - The repository contains no production secrets; create local configuration from the example env files.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [English](README.en.md) · [在线体验](https://luminbuddy2.ericdocmic.top/v2/) · [更新日志](#更新日志)
 
+**版本：OSS** — 包含完整治理写作内核、MCP、基础检索与扩展接口；不包含商业付费搜索 Provider、凭证配置或专有连接器。
+
 > **面向中文内容创作者的 AI 写作工作台**：从需求理解、素材检索、提纲确认，到按风格成稿、写后自检、反馈与记忆沉淀，把一次性生成变成可观察、可干预、可迭代的写作流程。
 
 ![笔润智谈写作工作台](docs/assets/luminbuddy-workspace.png)
@@ -12,18 +14,17 @@
 
 **笔润智谈**（LuminBuddy）是一款面向中文内容生产场景的 AI 写作助手。它不追求"一键生成"的魔法，而是将写作过程拆解为可观察、可干预、可迭代的工程流程——让创作者在关键决策点保持控制权，同时让 AI 在素材搜集、结构规划、风格适配和质量检查等环节提供有效辅助。
 
-**当前成熟度：工程 Beta**。已实现完整前后端、Harness 单层 Agent 编排、写作 Pipeline、引导式提纲、风格配置、A/B 评测、反馈系统、分层记忆与监控指标；持续迭代中。
+**当前成熟度：工程 Beta，治理内核已接入主流程。** Task1–13 已完成 WritingContract、计划编译、LCP/Document AST、typed Artifact、事务存储、运行时、三级质量门禁、V2 API、文档优先工作台、材料治理、shadow rollout 与生产接线。代码、构建、CI 和隔离环境的三条真实写作链路已通过；生产流量仍需完成 staging 证据归档、恢复/取消/回滚演练和凭证轮换。
 
-### 治理型写作运行时：目标架构与迁移边界
+### 治理型写作运行时
 
-V2 后续演进以 [治理型写作运行时](docs/19-governed-writing-runtime.md) 为唯一目标架构和协议基线，并按[实施计划](docs/plans/2026-08-27-governed-writing-runtime-implementation.md)逐步落地。新能力必须绑定版本化的 WritingContract、ExecutablePlan、Artifact、质量状态和 Snapshot；文档是主对象，聊天只负责修改合约、解释决策和控制执行。
+[治理型写作运行时](docs/19-governed-writing-runtime.md)是 V2 当前唯一权威写作内核。每个新任务必须绑定版本化的 WritingContract 和经过静态验证的 ExecutablePlan；模型与旧算子只能提交 typed Artifact 或 Revision，不能绕过质量门禁直接写正式文档。
 
-迁移期间，现有 Harness、Pipeline 和 Editorial DAG 继续作为执行器或兼容适配入口：
-
-- `agent.start` 与 `workflow.start` 暂时保持 wire 兼容，但不构成两套并行权威内核。
-- 旧 `mode` 与 `agent_mode` 不等同于新的 `task_mode`、`orchestration_mode` 和 `assurance_level`，不得复用旧字段承载新语义。
-- `agent.completed` 与 `workflow.completed` 只表示当前执行路径结束，不表示内容已经 Accepted、Verified 或正式提交。
-- Article Output Contract 只规定模型输出的流式 Markdown 解析边界；解析成功不等于 LCP 校验、Document AST 构建、版本提交或质量验收成功。
+- **文档是主对象**：聊天负责修改合约、解释决策和控制运行，正文、版本、引用和质量状态归属于文档。
+- **writingstore 是唯一事实源**：Contract、Plan、Run、Artifact、Decision、Ledger、Snapshot 与 canonical/shadow 内容统一持久化。
+- **质量状态不可伪造**：Candidate Draft、Accepted Draft、Verified Deliverable 逐级晋升；存在 BLOCKER、缺少必需验证器或完整快照时禁止 Verified。
+- **旧能力受控接入**：Harness、Pipeline、Editorial Role 通过 ExecutorAdapter 复用，不构成平行事实源；任何不满足合约、权限、预算或 lineage 的执行都 fail-closed。
+- **发布状态如实表达**：进程健康、运行结束或 Markdown 解析成功，都不等于内容已验收或生产流量已获批准。
 
 ---
 
@@ -33,31 +34,39 @@ V2 后续演进以 [治理型写作运行时](docs/19-governed-writing-runtime.m
 
 | 痛点 | 具体表现 | 笔润智谈的解决方案 |
 |------|---------|------------------|
-| **意图理解不稳定** | 用户的真实需求、篇幅和风格约束没有被准确捕捉 | 规则优先的意图路由 + 低置信度 LLM fallback |
-| **生成过程黑盒** | 素材检索、观点组织和成稿被压进一次不可观察的生成 | Harness 单层编排，每一步可见、可暂停、可恢复 |
-| **关键节点失控** | 用户无法在提纲确认、风格调整等高代价决策点干预 | Guided Mode 引导模式，提纲确认后再成稿 |
-| **反馈无法沉淀** | 好坏反馈没有进入下一次生成，团队难以定位失败环节 | 分段反馈 + A/B 评测 + 分层记忆系统 |
+| **意图理解不稳定** | 真实需求、篇幅、风格和证据约束容易在长上下文中漂移 | WritingContract 固化用户选择、推断来源和交付标准 |
+| **生成过程黑盒** | 素材、计划、执行和成稿被压进一次不可观察的生成 | ExecutablePlan、RunLedger 和 durable event 让步骤可见、可中止、可恢复 |
+| **素材失真或失联** | 多材料综合时来源、冲突和引用关系容易丢失 | MaterialAdapter、SourcePack、内容快照与 lineage 统一治理 |
+| **关键节点失控** | 用户无法在高成本、高风险决策前干预 | 自动与手动策略并行，高成本/高风险/手动设置必须先确认 |
+| **“生成完成”被误当成可交付** | 格式正确并不代表事实、风格和合约已经满足 | Candidate / Accepted / Verified 三级质量门禁与不可豁免 BLOCKER |
+| **运行失败难恢复** | 重试、重启和重复事件可能产生冲突版本 | 幂等提交、完整 Checkpoint、Snapshot、暂停/取消/回滚和 shadow 隔离 |
 
 ---
 
 ## 如何解决
 
-### 核心架构：Harness-LLM 单层持续会话
+### 核心架构：合约驱动的文档运行时
 
-借鉴 DeepSeek Harness (dsh) 的编排理念，采用**单层架构**：
-
+```text
+用户需求 / 材料 / 显式策略
+  → WritingContract（目标、风格、证据、预算、权限、审批）
+  → Strategy Compiler → ExecutablePlan（有界 DAG + Capability 绑定）
+  → Orchestrator → ExecutorAdapter（Harness / Engine Step / Editorial Role）
+  → typed Artifact + lineage + usage
+  → LCP / Document AST / RevisionSet
+  → Quality Gate（Candidate → Accepted → Verified）
+  → writingstore 原子提交 DocumentVersion + Snapshot + RunLedger
+  → 前端文档、运行摘要、详情报告和对话控制同步投影
 ```
-用户请求
-  → Harness（意图路由、工具注册、状态管理、断路保护）
-    → LLM 持续会话（自主决定调用什么工具、何时写作、何时修正）
-      ←→ 工具执行（搜索/知识库/写作/评审/修正）
-  → 流式输出到前端
-```
 
-**关键设计**：
-- **不存在外层 ReAct + 内层 agent loop 的嵌套**，降低延迟与输出漂移
-- **1 次 LLM 持续会话**替代传统 Pipeline 的 10+ 次独立调用，首字延迟从 30-60s 降至 3-5s
-- **会话状态跨轮持久化**：文章、素材、搜索记录在同一对话框内累积复用
+计划编译器可以从模板、能力注册表和受限扩展策略中选择执行方案；未知能力、无界重试、缺失输入、权限越界、预算溢出和缺少最终产物都会在执行前被拒绝。
+
+### 自动执行与用户控制
+
+- 普通任务：系统生成计划后立即执行，前端始终可查看、暂停或中止。
+- 高成本、高风险任务：必须先确认计划和预算。
+- 手动模式：尊重用户显式选择，系统建议不能静默覆盖。
+- 执行中修改：通过对话更新合约或发出控制指令，已提交文档版本不会被流式临时内容覆盖。
 
 ### 智能上下文管理
 
@@ -75,15 +84,16 @@ System Prompt 从全量注入（3000+ tokens）精简为常驻层（500-800 toke
 ### 写作流程
 
 ```text
-写作需求
-  → 意图识别（规则优先，毫秒级路由）
-  → 记忆检索（用户偏好注入）
-  → 素材检索（多源搜索 + 知识库 + 相关性过滤）
-  → 提纲确认（引导模式：确认/编辑/重做）
-  → 风格化流式写作（按 Profile 规则生成）
-  → 写后审校（质量评分 + 敏感检查）
-  → 自动修正（低严重度问题自动修复）
-  → 分段反馈 + A/B 评测 + 记忆沉淀
+创建或修改 WritingContract
+  → 归一化用户材料、网页来源与知识库结果
+  → 编译并验证 ExecutablePlan
+  → 自动执行，或按成本/风险/用户设置等待确认
+  → 生成提纲、章节、研究笔记、ClaimMap 等 typed Artifact
+  → 编译 Document AST 并形成 Candidate Draft
+  → 合约/风格/事实/引用/安全验证
+  → 无 BLOCKER 时晋升 Accepted Draft
+  → 必需验证器与完整 Snapshot 通过后形成 Verified Deliverable
+  → 用户编辑、RevisionSet、反馈、评测与记忆继续进入同一文档生命周期
 ```
 
 ---
@@ -94,18 +104,20 @@ System Prompt 从全量注入（3000+ tokens）精简为常驻层（500-800 toke
 
 | 功能 | 说明 |
 |------|------|
-| **意图识别** | 规则优先路由，支持写作/润色/压缩/扩写/自由对话 |
-| **多源检索** | 可扩展的多源搜索架构 + 内部知识库（BM25 + Dense + GraphRAG） |
-| **引导模式** | 提纲确认、编辑、最多五次重做 |
+| **WritingContract** | 固化任务模式、风格、材料、证据、预算、权限、审批与交付要求 |
+| **自适应计划** | T1–T4 信任等级、能力注册、静态验证与用户显式策略优先 |
+| **三类写作场景** | 长文创作、多材料综合、忠实改写及其 fail-closed 防御路径 |
+| **材料与来源治理** | Material/SourcePack/ClaimMap Artifact、冲突 Finding、引用与内容快照 |
 | **风格配置** | Style Profile 独立管理，支持版本、灰度发布和回滚 |
-| **流式输出** | WebSocket 实时推送，支持暂停/恢复/取消 |
+| **文档优先工作台** | 正文主舞台、可收起左栏、运行摘要、详情标签和底部可缩放对话 |
+| **持久化运行控制** | WebSocket durable event、暂停/恢复/取消、幂等提交与重启恢复 |
 | **富文本编辑** | Tiptap/ProseMirror 富文本编辑器，支持加粗、列表、引用、代码块等格式 |
-| **质量评审** | 6 维度评分（事实/结构/风格/修辞/篇幅/安全） |
-| **自动修正** | 评审未通过时自动修正，最多 3 次尝试 |
+| **三级质量治理** | Candidate / Accepted / Verified、验证器降级、BLOCKER 与完整审计报告 |
+| **隔离发布** | off/shadow/allowlist/percentage 策略、shadow 内容隔离、TTL 与回滚保护 |
 
 ### 写作工具集
 
-LLM 在持续会话中自主调用的工具：
+治理运行时可以通过 Capability Registry 调度以下内置或适配工具；工具输出必须转换为 typed Artifact，不能直接提交正式文档：
 
 | 工具 | 用途 |
 |------|------|
@@ -121,7 +133,7 @@ LLM 在持续会话中自主调用的工具：
 | `fact_check` | 提取事实声明并通过搜索验证 |
 | `retrieve_context` | 按需获取会话上下文 |
 
-> **搜索源扩展**：本仓库提供了 `SearchClient` 的完整接口和多源并发搜索框架。搜索源以独立模块形式接入，开发者可以参照 `search_stubs.go` 中的 stub 实现来对接自己的搜索源。
+> **搜索源边界**：OSS 提供通用检索契约、本地知识检索、共享网页抓取和扩展接口，不注册商业付费 Provider，也不包含其凭证变量或 CLI。
 
 ### 在线编辑与导出
 
@@ -144,15 +156,17 @@ LLM 在持续会话中自主调用的工具：
 
 ### 编辑部多 Agent 协作
 
-编辑部内部供稿流程的完整三 Agent 编排系统：
+编辑部研究、写作和审校角色作为受治理 Executor 能力接入统一 Orchestrator：
 
 ```
-人类编辑创建任务 → 研究Agent → 写作Agent → 审校Agent
-  → 质量路由：通过→待发布 / 一般问题→退回 / 严重问题→升级人工
+WritingContract → 受限角色计划 → 研究/写作/审校 Artifact
+  → 统一质量门禁 → 文档版本或人工决策
 ```
 
 - **角色化 Agent 执行器**（RoleAgentRunner）：每个 Agent 有独立 Persona、工具集和信号工具
 - **工具注册式管理**（EditorialToolRegistry）：新增工具只需 `Register`，无需修改 switch-case
+- **统一提交**：角色只返回 ExecutionResult，由 Orchestrator 写入 writingstore
+- **缺失依赖 fail-closed**：registry、权限、输入或 usage 不完整时拒绝伪造成功
 - **三层模型**：Event（客观事实）+ Decision（人类/系统选择）+ Transition（状态转换）
 - **质量路由**：信源数、信息缺口、验证声明自动评分，达标自动推进
 - **Agent 信誉**：记录成功率、Token 成本、质量评分
@@ -199,45 +213,29 @@ LLM 在持续会话中自主调用的工具：
 ## 技术架构
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│                    Frontend (React 19 + Vite)                 │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────────┐  │
-│  │ 写作工作台 │ │ 选题中心  │ │ 个人中心  │ │ Admin Dashboard │  │
-│  └─────┬────┘ └─────┬────┘ └─────┬────┘ └───────┬────────┘  │
-│        └────────────┴────────────┘              │           │
-│                     │                           │           │
-│              WebSocket + REST                   │           │
-└─────────────────────┼───────────────────────────┼───────────┘
-                      │                           │
-┌─────────────────────┼───────────────────────────┼───────────┐
-│              Go Backend (chi router)             │           │
-│                     │                           │           │
-│  ┌──────────────────┴───────────────────────────┴────────┐  │
-│  │                   Harness Agent Engine                 │  │
-│  │  ┌────────┐  ┌─────────┐  ┌────────┐  ┌────────────┐  │  │
-│  │  │ Intent │→ │ Search  │→ │ Write  │→ │PostReview  │  │  │
-│  │  │Routing │  │  Plan   │  │ Step   │  │   Step     │  │  │
-│  │  └────────┘  └─────────┘  └────────┘  └────────────┘  │  │
-│  │                                                        │  │
-│  │  ┌────────┐  ┌─────────┐  ┌────────┐  ┌────────────┐  │  │
-│  │  │ Memory │  │  Style  │  │  A/B   │  │  Feedback  │  │  │
-│  │  │  Gate  │  │ Profile │  │  Eval  │  │  System    │  │  │
-│  │  └────────┘  └─────────┘  └────────┘  └────────────┘  │  │
-│  └────────────────────────────────────────────────────────┘  │
-│                     │                                       │
-│  ┌──────────┬──────────┬──────────┬──────────┬──────────┐  │
-│  │ DeepSeek │  Search  │ IMA KB   │ DashScope│ MCP Server│  │
-│  │  Client  │  Client  │  Client  │ Embedding│ (JSON-RPC) │  │
-│  └──────────┴──────────┴──────────┴──────────┴──────────┘  │
-└─────────────────────┬───────────────────────────────────────┘
-                      │
-┌─────────────────────┼───────────────────────────────────────┐
-│              PostgreSQL 17 + pgvector + paradedb             │
-│  ┌─────────┬──────────┬──────────┬──────────┬────────────┐  │
-│  │ 用户数据 │ 风格配置  │ 知识库   │ 记忆系统  │ 会话日志   │  │
-│  │会话状态  │ A/B评测  │ GraphRAG │ 实体网络  │ 审计日志   │  │
-│  └─────────┴──────────┴──────────┴──────────┴────────────┘  │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ React 写作工作台                                                  │
+│ 左侧全局面板 │ 文档主舞台 │ 运行摘要 │ 详情标签 │ 底部对话控制     │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │ REST + WebSocket durable events
+┌───────────────────────────▼──────────────────────────────────────┐
+│ Go API / Governed Composition Root                               │
+│ Contract API │ Plan/Run API │ Document API │ Quality/Audit API   │
+├──────────────────────────────────────────────────────────────────┤
+│ writingkernel → writingplan → writingruntime → writingquality    │
+│ Contract       Compiler       Orchestrator      Validators        │
+│ LCP/AST        Registry       Recovery/Rollout  Quality Gates     │
+├──────────────────────────────────────────────────────────────────┤
+│ ExecutorAdapter: Harness Core │ Engine Step │ Editorial Role      │
+│ Shared capabilities: local retrieval │ web fetch │ MCP │ memory  │
+├──────────────────────────────────────────────────────────────────┤
+│ writingstore：Contract / Plan / Run / Artifact / Decision /       │
+│ Ledger / DocumentVersion / Snapshot / canonical / shadow          │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │
+┌───────────────────────────▼──────────────────────────────────────┐
+│ PostgreSQL 17 + pgvector + ParadeDB │ Redis wake-up │ object data │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ### 技术栈
@@ -247,10 +245,11 @@ LLM 在持续会话中自主调用的工具：
 | 前端 | React 19, Vite, TypeScript, Tailwind CSS, shadcn/ui, Tiptap/ProseMirror |
 | 后端 | Go 1.25+, chi router, coder/websocket |
 | 数据库 | PostgreSQL 17 + pgvector + paradedb (BM25) |
-| LLM | DeepSeek API (默认), 支持 OpenAI 兼容接口 |
+| LLM | DeepSeek API（默认），支持 OpenAI 兼容接口 |
 | Embedding | DashScope text-embedding-v3 (1024维) |
 | 部署 | Docker Compose, 1Panel |
-| 监控 | Prometheus 指标 + slog 结构化日志 + Trace 链路追踪 |
+| 运行协议 | LCP v1、WritingContract、ExecutablePlan、typed Artifact、durable RunEvent |
+| 监控 | Prometheus 指标 + slog 结构化日志 + RunLedger + Trace 链路追踪 |
 
 ---
 
@@ -260,11 +259,11 @@ LLM 在持续会话中自主调用的工具：
 
 ```bash
 cp .env.docker.example .env.docker
-# 编辑 .env.docker，填入模型 API Key 和数据库密码
+# 编辑 .env.docker，只填写本地所需的模型、Embedding 和数据库配置
 docker compose up -d
 ```
 
-默认入口：前端 `http://localhost:3002`，后端健康检查 `http://localhost:8080/api/v2/health`。
+默认入口：前端 `http://localhost:3002`；`/api/v2/health` 只表示进程存活，生产依赖请检查 `http://localhost:8080/api/v2/ready`。不要把真实凭证提交到仓库。
 
 ### 本地开发
 
@@ -283,9 +282,11 @@ npm run dev
 ### 验证
 
 ```bash
-cd backend && go test ./...
-cd frontend && npm ci && npm run build
+make verify
+docker compose config --quiet
 ```
+
+`make verify` 包含 Go 构建/全量测试以及前端 lint、生产构建和 WaBench 测试。启用 PostgreSQL 集成测试时应使用与 CI 一致、包含 `vector` 与 `pg_search` 的 ParadeDB 镜像，并设置 `TEST_DATABASE_URL`。
 
 ### 部署打包
 
@@ -299,13 +300,14 @@ cd frontend && npm ci && npm run build
 
 ### 搜索源扩展
 
-本仓库提供了搜索客户端的核心框架（`backend/internal/tools/search.go`），包含：
-- `SearchClient` 多源并发搜索结构体
-- `NewSearchClient` 构造函数
-- `Search` / `FetchHotTopics` 并发搜索方法
-- `KnowledgeSearcher` 知识库搜索接口
+OSS 共享以下能力：
 
-搜索源以独立模块形式接入。本仓库在 `search_stubs.go` 中提供了所有搜索源类型的 stub 实现，开发者可以参照这些 stub 来对接自己的搜索源：
+- 通用 `SearchClient` / `KnowledgeSearcher` 契约与 Capability Registry；
+- 本地知识检索、共享的有界网页抓取与正文抽取；
+- MCP Client/Server、工具发现、readiness 与安全沙箱；
+- 自定义搜索源的 fail-closed stub 和接入测试。
+
+付费搜索 Provider 的实现、凭证变量和商业 CLI 不属于 OSS。自定义搜索源必须返回受治理的 Source/SourcePack Artifact，并声明权限、超时、成本和稳定错误码：
 
 ```go
 // 示例：实现一个自定义搜索源
@@ -314,11 +316,11 @@ type MySearchClient struct { /* ... */ }
 func NewMySearchClient(/* params */) *MySearchClient { /* ... */ }
 
 func (c *MySearchClient) Search(ctx context.Context, query string, limit int) ([]engine.SearchResult, error) {
-    // 你的搜索逻辑
+    // 返回带来源、时间和可追溯元数据的结果
 }
 ```
 
-然后在 `NewSearchClient` 中初始化你的搜索源即可。
+不要通过伪成功或空结果假装未安装的 Provider 已就绪；`/ready` 必须区分 installed、configured、reachable 和 ready。
 
 ---
 
@@ -341,10 +343,25 @@ func (c *MySearchClient) Search(ctx context.Context, query string, limit int) ([
 | [Luminbuddy Eval Center](docs/16-wabench-eval-center.md) | 七个评测工作区、中文 Excel、评审溯源、仲裁、隐私与发布边界 |
 | [WritingAgentBench V2 执行](docs/14-wabench-v2-evaluation.md) | 真实 Harness Adapter、五项 Rubric、失败优先、独立红队和 Shadow 门禁 |
 | [运维手册](docs/runbook.md) | 部署、监控与故障排查 |
+| [治理型写作运行时](docs/19-governed-writing-runtime.md) | Contract、Plan、LCP、文档、质量、快照、前端与双版本边界 |
+| [Task1–12 实施计划](docs/plans/2026-08-27-governed-writing-runtime-implementation.md) | 从领域协议到工作台、材料与纵向发布门禁 |
+| [LCP v1](specs/lcp/v1/README.md) | Schema、枚举、fixtures 与三条写作场景 |
+| [Task11 材料治理](specs/task11-governed-materials/design.md) | MaterialAdapter、typed Artifact、冲突与单一事实源 |
+| [Task12 受治理放量](specs/task12-governed-rollout/design.md) | ExecutorAdapter、shadow 隔离、telemetry 与回滚 |
+| [Task13 生产接线记录](docs/releases/2026-08-30-task13-production-wiring-readiness.md) | 已通过证据、未通过生产门禁与凭证边界 |
 
 ---
 
 ## 更新日志
+
+### v0.8.0 (2026-08-31) — Task1–13 治理型写作平台
+
+- **Task1–4 · 协议与计划**：确立统一架构边界；实现 LCP v1、WritingContract、Document AST、RevisionSet、类型化 Writing Plan IR、Capability Registry 和 T1–T4 策略编译。
+- **Task5–7 · 持久化与执行**：完成治理数据库、事务 Repository、不可变 RunLedger、Snapshot 原子提交、状态机、ExecutorRegistry、预算/权限/审批门禁和有界恢复。
+- **Task8–10 · 质量、API 与工作台**：落地 Candidate/Accepted/Verified、不可豁免 BLOCKER、验证器降级、V2 Contract/Document/Run/Quality/Audit API，以及文档优先四区域工作台。
+- **Task11 · 材料治理**：MaterialAdapter、Material/Source typed Artifact、冲突 Finding、Orchestrator 单一提交和旧算子 B2 契约。
+- **Task12 · 受治理放量**：三类 ExecutorAdapter、shadow 内容隔离、rollout evidence、telemetry、防御矩阵和三条纵向场景。
+- **Task13 · 生产接线**：统一 composition root、readiness/provider preflight、MCP 并发修复、canonical/shadow 持久化和真实模型链路验收；生产流量继续受 staging 门禁约束。
 
 ### v0.7.0 (2026-08-24)
 
@@ -406,7 +423,8 @@ func (c *MySearchClient) Search(ctx context.Context, query string, limit int) ([
 ## 项目声明
 
 - 这是可运行的个人产品与工程项目，不代表已完成规模化市场验证。
-- 搜索源以独立模块形式接入，参照 `search_stubs.go` 中的 stub 实现自行对接。
+- 当前代码、构建、CI 与隔离真实链路已通过；这不等于生产部署或生产流量已获批准。
+- OSS 共享治理内核、MCP、基础检索、网页抓取与扩展契约，不包含商业付费搜索源实现和凭证。
 - 仓库不包含生产环境密钥；请从示例环境文件创建本地配置。
 
 ## License

--- a/docs/plans/2026-08-31-readme-task1-13-refresh-design.md
+++ b/docs/plans/2026-08-31-readme-task1-13-refresh-design.md
@@ -1,0 +1,39 @@
+# Task1–13 README 刷新设计
+
+## 目标
+
+让中英文 README 准确描述 Task1–13 完成后的 LuminBuddy：文档优先、合约驱动、计划可见、产物可追溯、质量可验收，并明确 OSS 与商业版的能力边界和真实发布状态。
+
+## 信息架构
+
+README 面向首次接触项目的创作者、开发者和部署者，不按任务编号展开实现细节。正文依次回答：
+
+1. 产品服务谁，以及长文创作、多材料综合、忠实改写三类核心场景；
+2. 自动执行和用户控制如何并行；
+3. WritingContract、ExecutablePlan、typed Artifact、质量门禁、writingstore 和文档版本如何构成主链路；
+4. Candidate Draft、Accepted Draft、Verified Deliverable 的含义；
+5. 如何启动、验证、扩展检索/MCP，以及当前能否生产放量；
+6. Task1–13 分别完成了哪组基础设施。
+
+旧 Harness、Pipeline、Editorial Role 不再被描述为第二套权威内核，而是通过 ExecutorAdapter 进入治理运行时的兼容执行能力。
+
+## 双版本策略
+
+两版共享产品定位、协议、核心运行时、本地检索、网页抓取、MCP、基础验证器和文档格式。OSS README 明确不包含付费搜索 Provider、商业凭证变量和商业 CLI；商业版 README 说明可配置的付费搜索、治理与运维能力，但不记录密钥或供应商响应。
+
+## 真实性约束
+
+- 不把代码合并、容器启动或健康检查表述为生产上线。
+- 明确代码、构建、CI 与隔离真实链路已经通过。
+- 明确生产流量仍受 staging 质量归档、恢复/取消/回滚演练、凭证轮换和 rollout 决策约束。
+- 不声称 Candidate 已经等同 Accepted 或 Verified。
+- 中英文语义一致，版本差异只出现在明确标注的 edition 段落。
+
+## 验证
+
+- Markdown 结构、相对链接和中英文标题完整；
+- README 中不存在“治理运行时仍待逐步落地”的过期表述；
+- README 中不存在把 Harness 描述为唯一当前核心的过期表述；
+- OSS 不出现商业付费凭证变量或把付费搜索描述为内置；
+- make verify 仍为唯一推荐的本地综合门禁；
+- FILE_INDEX.md 同步记录 README 与本设计/计划。

--- a/docs/plans/2026-08-31-readme-task1-13-refresh.md
+++ b/docs/plans/2026-08-31-readme-task1-13-refresh.md
@@ -1,0 +1,60 @@
+# Task1–13 README Refresh Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refresh both editions' Chinese and English README files so they truthfully present the governed writing platform delivered in Task1–13.
+
+**Architecture:** Keep one shared product and runtime narrative, then apply a narrow edition-specific capability section. Treat existing design, specification, release-readiness, code, and CI evidence as the source of truth.
+
+**Tech Stack:** Markdown, Git, ripgrep, repository Makefile validation, GitHub Actions.
+
+---
+
+### Task 1: Establish the documentation baseline
+
+**Files:**
+- Create: `docs/plans/2026-08-31-readme-task1-13-refresh-design.md`
+- Create: `docs/plans/2026-08-31-readme-task1-13-refresh.md`
+- Modify: `FILE_INDEX.md`
+
+1. Record audience, information architecture, edition boundaries, and truthfulness constraints.
+2. Register the new documentation responsibilities in the file index.
+3. Verify both repositories contain the same design and plan.
+
+### Task 2: Refresh the Chinese README
+
+**Files:**
+- Modify: `README.md`
+
+1. Replace the migration-target language with the implemented governed-runtime status.
+2. Replace the legacy Harness-first architecture and flow with Contract → Plan → Artifact → Quality → writingstore → Document.
+3. Add execution-control, quality-state, material-governance, recovery, and observability descriptions.
+4. Correct Quick Start, validation, search/MCP boundary, design-document links, and production status.
+5. Add a v0.8.0 Task1–13 grouped changelog.
+
+### Task 3: Refresh the English README
+
+**Files:**
+- Modify: `README.en.md`
+
+1. Mirror the Chinese information architecture and claims.
+2. Preserve natural English rather than literal translation.
+3. Keep product states, error boundaries, commands, and release status semantically identical.
+
+### Task 4: Apply edition-specific boundaries
+
+**Files:**
+- Modify: OSS `README.md`, `README.en.md`
+- Modify: Commercial `README.md`, `README.en.md`
+
+1. State that interfaces, MCP, local retrieval, and bounded web fetching are shared.
+2. State that OSS excludes paid Provider implementations, credentials, and commercial CLIs.
+3. State that Commercial may register governed paid search adapters without exposing secrets.
+
+### Task 5: Validate and deliver
+
+1. Run Markdown structure and relative-link checks.
+2. Search for stale target-architecture and legacy-primary wording.
+3. Compare shared sections across editions and review intentional differences.
+4. Run `git diff --check`.
+5. Commit and push one documentation branch per repository, then open PRs.


### PR DESCRIPTION
## Summary\n- refresh the Chinese and English project entry points for Task1–13\n- document the governed writing runtime, document-first workflow, quality states, and sole-source-of-truth boundary\n- clarify automatic/manual execution policy and edition-specific search/MCP boundaries\n- record current Engineering Beta readiness and remaining production gates\n- add the README refresh design/implementation records and update FILE_INDEX.md\n\n## Validation\n- Markdown relative-link checks passed\n- git diff --check passed\n- Chinese/English structure and Task1–13 coverage checked\n- OSS/commercial differences reviewed and limited to intended edition boundaries